### PR TITLE
Update handbook_01_history.tex

### DIFF
--- a/handbook_01_history.tex
+++ b/handbook_01_history.tex
@@ -890,7 +890,7 @@
 							\end{enumerate}
 						}
 						\item{\underline{Means of Appeal}:  Appeal of actions by the Academic Senate shall be brought to the full faculty upon the request of seven persons with faculty status who have both voice and vote.}
-						\item{\underline{Subcommittee Assignment}:  Senators, excluding the chair, are appointed annually to 1-year terms on the subcommittees of the Academic Senate (Review Committee and Academic Resources Committee; three senators each) and the Strategic Planning Committee (two senators).  Appointments are made by the Provost in consultation with the Academic Senate Vice-Chair elect.  These appointments will occur in the spring term following Academic Senate elections, with the aim of maximizing continuity on the committee, divisional representation, and fit of expertise and experience.}
+						\item{\underline{Subcommittee Assignment}:  Senators, excluding the chair, are appointed annually to 1-year terms on the subcommittee of the Academic Senate (Review Committee; three senators) and the Strategic Planning Committee (two senators).  Appointments are made by the Provost in consultation with the Academic Senate Vice-Chair elect.  These appointments will occur in the spring term following Academic Senate elections, with the aim of maximizing continuity on the committee, divisional representation, and fit of expertise and experience.}
 					\end{enumerate}
 				\subparagraph{Academic Senate:  Review Committee}
 					\begin{enumerate}[label=\alph*)]
@@ -911,38 +911,6 @@
 								\item{Acts for the Academic Senate on student petition appeals, honors and alternative-major proposals.}
 								\item{Acts upon minor curricular changes that do not involve, for example, the addition or deletion of a major, a change in units required for a major, or any change that signals a major shift in emphasis of the College.}
 								\item{Appeals for action related to student petitions, honors, and alternative-major proposals shall be to the Provost; appeals for action to minor curricular changes shall be to the Academic Senate.}
-							\end{enumerate}
-						}
-					\end{enumerate}
-				\subparagraph{Academic Senate:  Academic Resources Committee}
-					The Academic Resources Committee (ARC) is concerned with recommending and implementing resources suitable for faculty and student use in the classroom and in the library.  Additionally, the ARC makes recommendations to the Academic Senate regarding policy on use of instructional resources.
-					\begin{enumerate}[label=\alph*)]
-						\item{\underline{Membership}:
-							\begin{enumerate}[label=\arabic*)]
-								\item{Provost or representative}
-								\item{Director of Library \& Information Services (ex-officio)}
-								\item{Director of Information Technology (ex-officio)}
-								\item{Three senators, each appointed annually by the Provost and Academic Senate chair to renewable 1 year terms.}
-								\item{One additional full-time faculty member, selected by the Provost in consultation with Faculty Council, to serve a three-year term as committee chair}
-								\item{One student appointed by W.C.S.A.}
-								\item{On an ad hoc basis, such members of the library faculty or staff who may be required for a specific purpose, who will have voice without vote}
-							\end{enumerate}
-							All Academic Senate members shall have voice without vote at every meeting.
-						}
-						\item{\underline{Reports to}:
-							\begin{enumerate}[label=\arabic*)]
-								\item{In matters regarding policy that affect instruction, the ARC reports to the Academic Senate.}
-								\item{In matters regarding acquisition and implementation of technology, the ARC makes recommendations to the Director of Information Technology and reports to the Provost.}
-							\end{enumerate}
-						}
-						\item{\underline{Purposes}:
-							\begin{enumerate}[label=\arabic*)]
-								\item{To assist the Director of Information Technology in determining what new technologies and products are appropriate for Westmont College, and which should be evaluated for instructional use.}
-								\item{To propose the acquisition and implementation of new instructional resources.}
-								\item{To work with the Director of Information Technology in educating and enabling faculty in the use of new and existing resources.}
-								\item{To recommend policy relating to technology issues that affect faculty and students.}
-								\item{To work with the Director of Library \& Information Services in library-related matters, including collection development, building-related matters, staffing, programs, and budgetary issues.}
-								\item{To refer items (as appropriate) to the Senate for their recommendation to the faculty.}
 							\end{enumerate}
 						}
 					\end{enumerate}
@@ -1036,36 +1004,38 @@
 							\end{enumerate}
 						}
 					\end{enumerate}
-				\subparagraph{Computer and Technology Advisory Committee}
+				\subparagraph{Academic Resources Committee}
+					The Academic Resources Committee (ARC) is concerned with reviewing, recommending and implementing resources suitable for faculty and student use in the classroom, the library, and in the area of information technology. Additionally, the ARC reviews and makes recommendations to the College regarding budget allocation and prioritization of instructional resources. Such recommendations should account for the sustainability of new resources as well as the maintenance of old resources.
 					\begin{enumerate}[label=\alph*)]
 						\item{\underline{Membership}:
 							\begin{enumerate}[label=\arabic*)]
-								\item{Academic -The chair of the Academic
-									Resources Committee of the Senate and one
-									faculty member elected to a three year term,
-									recommended by Faculty Council and approved by
-									the Faculty.  The Director of the Library and
-									Information Services or designated
-									representative serves as an \emph{ex officio} member.}
-								\item{Administrative - Registrar, Vice President for Finance, Director of Admissions, one representative from Advancement and Student Life}
-								\item{Two students appointed by WCSA}
-								\item{Chief Information Officer or designated representative}
-								\item{Ex Officio - As needed}
+							\item{Provost or representative (ex-officio)}
+							\item{Director of Library \& Information Services or representative (ex-officio)}
+							\item{Chief Information Officer or representative (ex-officio)}
+							\item{Three faculty, preferably one from each division, one elected annually to a three-year term}
+							\item{One student appointed by W.C.S.A.}
+							\item{On an ad hoc basis, such members of the library and information technology faculty or staff who may be required for a specific purpose, who will have voice without vote}
 							\end{enumerate}
 						}
-						\item{\underline{Officers}:
-							The Committee shall be chaired by the Director of Information Technology or designated representative.
-						}
-						\item{\underline{Responsibilities}:
+					      \item{\underline{Officers}:
+							The chair will be elected from among the tenured faculty members and shall appoint the secretary}	
+      						\item{\underline{Reports to}:
 							\begin{enumerate}[label=\arabic*)]
-								\item{To review and recommend plans and priorities for the College in the area of information technology.}
-								\item{To review and recommend specific policies regarding computer and information technology.}
-								\item{To review and recommend staffing and budget.}
-								\item{To review and recommend new initiatives and innovations.}
-								\item{To review progress toward established goals and objectives.}
+							\item{In matters regarding policy that affect instruction, the ARC reports to the Academic Senate and Provost.}
+							\item{In matters regarding acquisition and implementation of technology, the ARC makes recommendations to the Chief Information Officer and reports to the Provost.}
 							\end{enumerate}
-						}
+       						}
+						\item{\underline{Purposes}:
+							\begin{enumerate}[label=\arabic*)]
+							\item{To assist the Chief Information Officer in determining what new technologies and products are appropriate for Westmont College, and which should be evaluated for instructional use.
+							\item{To propose the acquisition and implementation of new instructional resources, and to advocate for the maintenance and upkeep of existing facilities and instructional resources.}
+							\item{To advocate for and recommend policy relating to technology issues that affect faculty and students.}
+							\item{To assist the Director of Library & Information Services in library-related matters that affect faculty and students, including collection development, building-related matters, staffing, programs, and budgetary issues.}
+							\item{To refer items (as appropriate) to the Academic Senate for their recommendation to the faculty.}
+							\item{The Chief Information Officer or a designate will as needed provide updates to the ARC on support or procurement related challenges specific to the classroom and other academic technology areas.}
+							\item{To review and make recommendations to the Provost (or representative) and Capital Improvement Project committee regarding budget allocation for items that affect faculty and students.}
 					\end{enumerate}
+						}     
 				\subparagraph{Athletic Committee}
 					\begin{enumerate}[label=\alph*)]
 						\item{\underline{Membership}:


### PR DESCRIPTION
This is a Faculty and BOT-approved Handbook change that updates membership, purposes, and reporting structure for the ARC committee, which will report to the Senate and the Provost. The committee moves away from under the Senate and replaces CTAC in the list of administrative committees overseen by Faculty Council.